### PR TITLE
Correctly handle non-utf8 arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,8 +816,8 @@ impl Matches {
         })
     }
 
-    /// Returns the string argument supplied to one of several matching options or `None`.
-    pub fn opts_str(&self, names: &[String]) -> Option<OsString> {
+    /// Returns the argument supplied to one of several matching options or `None`.
+    pub fn opts_str_os(&self, names: &[String]) -> Option<OsString> {
         names.iter().filter_map(|nm| {
             match self.opt_val(&nm) {
                 Some(Val(s)) => Some(s),
@@ -826,11 +826,18 @@ impl Matches {
         }).next()
     }
 
+    /// Returns the string argument supplied to one of several matching options or `None`.
+    ///
+    /// Panics if the argument cannot be decoded to a string.
+    pub fn opts_str(&self, names: &[String]) -> Option<String> {
+        self.opts_str_os(names).map(|s| s.into_string().unwrap())
+    }
+
     /// Returns a vector of the arguments provided to all matches of the given
     /// option.
     ///
     /// Used when an option accepts multiple values.
-    pub fn opt_strs(&self, nm: &str) -> Vec<OsString> {
+    pub fn opt_strs_os(&self, nm: &str) -> Vec<OsString> {
         self.opt_vals(nm).into_iter().filter_map(|v| {
             match v {
                 Val(s) => Some(s),
@@ -839,12 +846,29 @@ impl Matches {
         }).collect()
     }
 
+    /// Returns a vector of the arguments provided to all matches of the given
+    /// option.
+    ///
+    /// Used when an option accepts multiple values.
+    ///
+    /// Panics if one of the arguments cannot be decoded to a string.
+    pub fn opt_strs(&self, nm: &str) -> Vec<String> {
+        self.opt_strs_os(nm).into_iter().map(|s| s.into_string().unwrap()).collect()
+    }
+
     /// Returns the string argument supplied to a matching option or `None`.
-    pub fn opt_str(&self, nm: &str) -> Option<OsString> {
+    pub fn opt_str_os(&self, nm: &str) -> Option<OsString> {
         match self.opt_val(nm) {
             Some(Val(s)) => Some(s),
             _ => None,
         }
+    }
+
+    /// Returns the string argument supplied to a matching option or `None`.
+    ///
+    /// Panics if the argument cannot be decoded to a string.
+    pub fn opt_str(&self, nm: &str) -> Option<String> {
+        self.opt_str_os(nm).map(|s| s.into_string().unwrap())
     }
 
 
@@ -853,10 +877,25 @@ impl Matches {
     /// Returns none if the option was not present, `def` if the option was
     /// present but no argument was provided, and the argument if the option was
     /// present and an argument was provided.
-    pub fn opt_default(&self, nm: &str, def: &OsStr) -> Option<OsString> {
+    pub fn opt_default_os(&self, nm: &str, def: &OsStr) -> Option<OsString> {
         match self.opt_val(nm) {
             Some(Val(s)) => Some(s),
             Some(_) => Some(def.to_owned()),
+            None => None,
+        }
+    }
+
+    /// Returns the matching string, a default, or none.
+    ///
+    /// Returns none if the option was not present, `def` if the option was
+    /// present but no argument was provided, and the argument if the option was
+    /// present and an argument was provided.
+    ///
+    /// Panics if the argument was provided but cannot be decoded to a string.
+    pub fn opt_default(&self, nm: &str, def: &str) -> Option<String> {
+        match self.opt_val(nm) {
+            Some(Val(s)) => Some(s.into_string().unwrap()),
+            Some(_) => Some(def.to_string()),
             None => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //!     }
 //!     let output = matches.opt_str("o");
 //!     let input = if !matches.free.is_empty() {
-//!         matches.free[0].clone()
+//!         matches.free[0].clone().into_string().unwrap()
 //!     } else {
 //!         print_usage(&program, opts);
 //!         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1377,7 +1377,7 @@ mod tests {
           Ok(ref m) => {
             // The next variable after the flag is just a free argument
 
-            assert!(m.free[0] == "20");
+            assert!(m.free[0].to_str().unwrap() == "20");
           }
           _ => panic!()
         }
@@ -1577,7 +1577,7 @@ mod tests {
         match Options::new().parse(&args) {
             Ok(ref m) => {
                 assert_eq!(m.free.len(), 1);
-                assert_eq!(m.free[0], "-");
+                assert_eq!(m.free[0].to_str().unwrap(), "-");
             }
             _ => panic!()
         }
@@ -1628,10 +1628,10 @@ mod tests {
                       .optopt("", "notpresent", "nothing to see here", "NOPE")
                       .parse(&args) {
           Ok(ref m) => {
-            assert!(m.free[0] == "prog");
-            assert!(m.free[1] == "free1");
+            assert!(m.free[0].to_str().unwrap() == "prog");
+            assert!(m.free[1].to_str().unwrap() == "free1");
             assert_eq!(m.opt_str("s").unwrap(), "20");
-            assert!(m.free[2] == "free2");
+            assert!(m.free[2].to_str().unwrap() == "free2");
             assert!((m.opt_present("flag")));
             assert_eq!(m.opt_str("long").unwrap(), "30");
             assert!((m.opt_present("f")));
@@ -1664,9 +1664,9 @@ mod tests {
             assert!(m.opt_present("a"));
             assert!(!m.opt_present("c"));
             assert_eq!(m.free.len(), 3);
-            assert_eq!(m.free[0], "b");
-            assert_eq!(m.free[1], "-c");
-            assert_eq!(m.free[2], "d");
+            assert_eq!(m.free[0].to_str().unwrap(), "b");
+            assert_eq!(m.free[1].to_str().unwrap(), "-c");
+            assert_eq!(m.free[2].to_str().unwrap(), "d");
           }
           _ => panic!()
         }
@@ -1689,9 +1689,9 @@ mod tests {
             assert!(m.opt_present("a"));
             assert!(!m.opt_present("c"));
             assert_eq!(m.free.len(), 3);
-            assert_eq!(m.free[0], "-");
-            assert_eq!(m.free[1], "-c");
-            assert_eq!(m.free[2], "d");
+            assert_eq!(m.free[0].to_str().unwrap(), "-");
+            assert_eq!(m.free[1].to_str().unwrap(), "-c");
+            assert_eq!(m.free[2].to_str().unwrap(), "d");
           }
           _ => panic!()
         }


### PR DESCRIPTION
Fixes #28

This changes all the internal machinery to operate on OsString and &OsStr instead of String and &str. This means the parser doesn't panic anymore when fed arguments that don't decode as UTF-8.

I went the compatible route by adding new methods with an `_os` suffix, e.g. `opt_str_os()`; the old methods still exist but might panic (the same way `parse()` could previously panic). The remaining compatibility issue is the `Matches#free` attribute.

This needs non-unicode tests (the current tests pass) and implementation of the Argument trait for Windows (a first step might be to implement it for valid unicode).

Let me know if you are interested in this, I certainly am. Having getopts fail on some arguments is bad enough, the way it panics is a real problem.
