### PR TITLE
Sfr/optiongroup and friends

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,20 @@ impl Options {
         self
     }
 
+    /// TODO: write a documentation
+    pub fn separator(&mut self) -> &mut Options {
+        self.grps.push(OptGroup {
+            short_name: "".to_string(),
+            long_name: "".to_string(),
+            hint: "".to_string(),
+            desc: "".to_string(),
+            hasarg: No,
+            occur: Optional,
+            variant: Separator,
+        });
+        self
+    }
+
     /// Parse command line arguments according to the provided options.
     ///
     /// On success returns `Ok(Matches)`. Use methods such as `opt_present`
@@ -469,9 +483,15 @@ impl Options {
                          hint,
                          desc,
                          hasarg,
+                         variant,
                          ..} = (*optref).clone();
 
             let mut row = "    ".to_string();
+
+            if variant == Separator {
+                row = "".to_string();
+                return row;
+            }
 
             // short option
             match short_name.len() {
@@ -618,6 +638,8 @@ struct Opt {
 pub enum Variant {
     /// A normal option
     OptionGroup,
+    /// A separator
+    Separator,
 }
 
 /// One group of options, e.g., both `-h` and `--help`, along with
@@ -731,6 +753,18 @@ impl OptGroup {
             variant,
             ..
         } = (*self).clone();
+
+        if variant == Separator {
+            let opt = Opt {
+                name: Long((long_name)),
+                hasarg: hasarg,
+                occur: occur,
+                aliases: Vec::new(),
+                variant: variant,
+            };
+
+            return opt;
+        }
 
         match (short_name.len(), long_name.len()) {
             (0,0) => panic!("this long-format option was given no name"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ use self::HasArg::*;
 use self::Occur::*;
 use self::Fail::*;
 use self::Optval::*;
+use self::Variant::*;
 use self::SplitWithinState::*;
 use self::Whitespace::*;
 use self::LengthLimit::*;
@@ -152,7 +153,8 @@ impl Options {
             hint: hint.to_string(),
             desc: desc.to_string(),
             hasarg: hasarg,
-            occur: occur
+            occur: occur,
+            variant: OptionGroup,
         });
         self
     }
@@ -172,7 +174,8 @@ impl Options {
             hint: "".to_string(),
             desc: desc.to_string(),
             hasarg: No,
-            occur: Optional
+            occur: Optional,
+            variant: OptionGroup,
         });
         self
     }
@@ -193,7 +196,8 @@ impl Options {
             hint: "".to_string(),
             desc: desc.to_string(),
             hasarg: No,
-            occur: Multi
+            occur: Multi,
+            variant: OptionGroup,
         });
         self
     }
@@ -215,7 +219,8 @@ impl Options {
             hint: hint.to_string(),
             desc: desc.to_string(),
             hasarg: Maybe,
-            occur: Optional
+            occur: Optional,
+            variant: OptionGroup,
         });
         self
     }
@@ -238,7 +243,8 @@ impl Options {
             hint: hint.to_string(),
             desc: desc.to_string(),
             hasarg: Yes,
-            occur: Multi
+            occur: Multi,
+            variant: OptionGroup,
         });
         self
     }
@@ -260,7 +266,8 @@ impl Options {
             hint: hint.to_string(),
             desc: desc.to_string(),
             hasarg: Yes,
-            occur: Optional
+            occur: Optional,
+            variant: OptionGroup,
         });
         self
     }
@@ -282,7 +289,8 @@ impl Options {
             hint: hint.to_string(),
             desc: desc.to_string(),
             hasarg: Yes,
-            occur: Req
+            occur: Req,
+            variant: OptionGroup,
         });
         self
     }
@@ -601,6 +609,15 @@ struct Opt {
     occur: Occur,
     /// Which options it aliases
     aliases: Vec<Opt>,
+    /// Its a option or only a variant?
+    variant: Variant,
+}
+
+/// type of Option group
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Variant {
+    /// A normal option
+    OptionGroup,
 }
 
 /// One group of options, e.g., both `-h` and `--help`, along with
@@ -618,7 +635,9 @@ struct OptGroup {
     /// Whether option has an argument
     hasarg: HasArg,
     /// How often it can occur
-    occur: Occur
+    occur: Occur,
+    /// Type of OptionGroup
+    variant: Variant,
 }
 
 /// Describes whether an option is given at all or has a value.
@@ -709,6 +728,7 @@ impl OptGroup {
             long_name,
             hasarg,
             occur,
+            variant,
             ..
         } = (*self).clone();
 
@@ -718,24 +738,28 @@ impl OptGroup {
                 name: Long((long_name)),
                 hasarg: hasarg,
                 occur: occur,
-                aliases: Vec::new()
+                aliases: Vec::new(),
+                variant: variant,
             },
             (1,0) => Opt {
                 name: Short(short_name.as_bytes()[0] as char),
                 hasarg: hasarg,
                 occur: occur,
-                aliases: Vec::new()
+                aliases: Vec::new(),
+                variant: variant,
             },
             (1,_) => Opt {
                 name: Long((long_name)),
                 hasarg: hasarg,
                 occur: occur,
+                variant: variant,
                 aliases: vec!(
                     Opt {
                         name: Short(short_name.as_bytes()[0] as char),
                         hasarg: hasarg,
                         occur:  occur,
-                        aliases: Vec::new()
+                        aliases: Vec::new(),
+                        variant: variant,
                     }
                 )
             },


### PR DESCRIPTION
Please review my code and if its okay include it to your repository. Please review carefully I'm new in rust.

As @alexcrichton has suggested some more information to this PR.

I have added a example repository [here](https://github.com/silvio/rust-getopts-test).

* The first patch is the base for the other two patches. I introduce a content information for `Opt` and `OptGroup` (named variant) to differ between some modes. The first variant is `OptionGroup` for the current implementation.
* The second patch use the first patch. It introduce a new variant `Separator` and the public accessible function `separator()` which results in a blank line at `usage()` call.
* The third patch add two new functions `description()` and `description_header()` for the new variant `Description` which results in some desciptive text at `usage()` call.

## Example separator:

This ...

```
opts.optflag("R", "recursive", "operate on files and directories recursively");
opts.separator();
opts.optflag("H", "", "if a command line argument is a symbolic link to a directory, traverse it");
```
... results in this:

```
[...]
    -R, --recursive     operate on files and directories recursively

    -H                  if a command line argument is a symbolic link to a
                        directory, traverse it
[...]
```

## Example description*():

This:

```
[...]
opts.optflag("R", "recursive", "operate on files and directories recursively");
opts.description_header("Flags for -R");
opts.description("The following options modify how a hierarchy \
                  is traversed when the -R option is also specified.  \
                  If more than one is specified, only the final one \
                  takes effect.")
opts.optflag("H", "", "if a command line argument is a symbolic link \
                       to a directory, traverse it");
[...]
```

The result is:

```
[...]
    -R, --recursive     operate on files and directories recursively

    Flags for -R:
        The following options modify how a hierarchy is traversed when the -R
        option is also specified. If more than one is specified, only the final
        one takes effect.
    -H                  if a command line argument is a symbolic link to a
                        directory, traverse it
[...]
```
