### PR TITLE
Add helpful explanation to failed assertions validating arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl Options {
     pub fn opt(&mut self, short_name: &str, long_name: &str, desc: &str,
                        hint: &str, hasarg: HasArg, occur: Occur) -> &mut Options {
         let len = short_name.len();
-        assert!(len == 1 || len == 0);
+        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -165,7 +165,7 @@ impl Options {
     pub fn optflag(&mut self, short_name: &str, long_name: &str, desc: &str)
                            -> &mut Options {
         let len = short_name.len();
-        assert!(len == 1 || len == 0);
+        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -186,7 +186,7 @@ impl Options {
     pub fn optflagmulti(&mut self, short_name: &str, long_name: &str, desc: &str)
                                 -> &mut Options {
         let len = short_name.len();
-        assert!(len == 1 || len == 0);
+        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -208,7 +208,7 @@ impl Options {
     pub fn optflagopt(&mut self, short_name: &str, long_name: &str, desc: &str,
                               hint: &str) -> &mut Options {
         let len = short_name.len();
-        assert!(len == 1 || len == 0);
+        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -231,7 +231,7 @@ impl Options {
     pub fn optmulti(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str)
                             -> &mut Options {
         let len = short_name.len();
-        assert!(len == 1 || len == 0);
+        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -253,7 +253,7 @@ impl Options {
     pub fn optopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str)
                           -> &mut Options {
         let len = short_name.len();
-        assert!(len == 1 || len == 0);
+        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -275,7 +275,7 @@ impl Options {
     pub fn reqopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str)
                           -> &mut Options {
         let len = short_name.len();
-        assert!(len == 1 || len == 0);
+        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,7 @@ impl Options {
     /// Create a generic option group, stating all parameters explicitly.
     pub fn opt(&mut self, short_name: &str, long_name: &str, desc: &str,
                        hint: &str, hasarg: HasArg, occur: Occur) -> &mut Options {
-        let len = short_name.len();
-        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
+        validate_shortname(short_name);
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -164,8 +163,7 @@ impl Options {
     /// * `desc` - Description for usage help
     pub fn optflag(&mut self, short_name: &str, long_name: &str, desc: &str)
                            -> &mut Options {
-        let len = short_name.len();
-        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
+        validate_shortname(short_name);
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -185,8 +183,7 @@ impl Options {
     /// * `desc` - Description for usage help
     pub fn optflagmulti(&mut self, short_name: &str, long_name: &str, desc: &str)
                                 -> &mut Options {
-        let len = short_name.len();
-        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
+        validate_shortname(short_name);
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -207,8 +204,7 @@ impl Options {
     ///   e.g. `"FILE"` for a `-o FILE` option
     pub fn optflagopt(&mut self, short_name: &str, long_name: &str, desc: &str,
                               hint: &str) -> &mut Options {
-        let len = short_name.len();
-        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
+        validate_shortname(short_name);
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -230,8 +226,7 @@ impl Options {
     ///   e.g. `"FILE"` for a `-o FILE` option
     pub fn optmulti(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str)
                             -> &mut Options {
-        let len = short_name.len();
-        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
+        validate_shortname(short_name);
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -252,8 +247,7 @@ impl Options {
     ///   e.g. `"FILE"` for a `-o FILE` option
     pub fn optopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str)
                           -> &mut Options {
-        let len = short_name.len();
-        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
+        validate_shortname(short_name);
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -274,8 +268,7 @@ impl Options {
     ///   e.g. `"FILE"` for a `-o FILE` option
     pub fn reqopt(&mut self, short_name: &str, long_name: &str, desc: &str, hint: &str)
                           -> &mut Options {
-        let len = short_name.len();
-        assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
+        validate_shortname(short_name);
         self.grps.push(OptGroup {
             short_name: short_name.to_string(),
             long_name: long_name.to_string(),
@@ -545,6 +538,11 @@ impl Options {
         format!("{}\n\nOptions:\n{}\n", brief,
                 rows.collect::<Vec<String>>().connect("\n"))
     }
+}
+
+fn validate_shortname(short_name: &str) {
+    let len = short_name.len();
+    assert!(len == 1 || len == 0, "The short_name (first argument) should be a single character, or an empty string for none");
 }
 
 /// What parsing style to use when parsing arguments.


### PR DESCRIPTION
Without these assertion messages I was getting a slightly unhelpful.  (Only "slightly" in that I could go read the code and see what the problem was \o/).

```
thread '<main>' panicked at 'assertion failed: len == 1 || len == 0', /Users/sam/.cargo/registry/src/github.com-88ac128001ac3a9a/getopts-0.2.14/src/lib.rs:256
```

With this change it looks more like:
```
thread '<main>' panicked at 'The short_name (first argument) should be a single character, or an empty string for none', /Users/sam/.cargo/registry/src/github.com-88ac128001ac3a9a/getopts-0.2.14/src/lib.rs:256
```

Slightly more helpful I think. Is there any way to highlight which caller is at fault rather than saying, failed at `getopts/src/lib.rs:256`?  I noticed https://github.com/rust-lang/rfcs/pull/466, but it seemed to have become stale, argument validation code would be a nice use case for this. 

On another, slightly related note, the backtrace is very noisy in nightly with a debug build for such a simple error.

```
   1:        0x106bd1a58 - sys::backtrace::tracing::imp::write::h268482af15af0a80Y8t
   2:        0x106bd2d95 - panicking::default_handler::_$u7b$$u7b$closure$u7d$$u7d$::closure.42271
   3:        0x106bd2996 - panicking::default_handler::h97bc664f7e2bfeb5Ocy
   4:        0x106bcbf56 - sys_common::unwind::begin_unwind_inner::h98c0975c9b6b2fa0Zbt
   5:        0x106bbb727 - sys_common::unwind::begin_unwind::h17795360225358885000
   6:        0x106bbe9c1 - Options::optopt::h116ec89e175831682ga
   7:        0x106ba99c7 - main::h0211dfa76348bfdfyba
   8:        0x106bd25c2 - sys_common::unwind::try::try_fn::h9072539541001871658
   9:        0x106bd0ffb - __rust_try
  10:        0x106bd2471 - rt::lang_start::hacfbaccc148e05fdU4x
  11:        0x106bbb4d9 - main
```