### PR TITLE
No panicking on invalid option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,7 +748,7 @@ impl Matches {
     fn opt_vals(&self, nm: &str) -> Vec<Optval> {
         match find_opt(&self.opts, Name::from_str(nm)) {
             Some(id) => self.vals[id].clone(),
-            None => Vec::new()
+            None => panic!("No option '{}' defined", nm)
         }
     }
 
@@ -756,7 +756,7 @@ impl Matches {
         self.opt_vals(nm).into_iter().next()
     }
     /// Returns true if an option was defined
-    pub fn is_opt_defined(&self, nm: &str) -> bool {
+    pub fn opt_defined(&self, nm: &str) -> bool {
         find_opt(&self.opts, Name::from_str(nm)).is_some()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -755,6 +755,10 @@ impl Matches {
     fn opt_val(&self, nm: &str) -> Option<Optval> {
         self.opt_vals(nm).into_iter().next()
     }
+    /// Returns true if an option was defined
+    pub fn is_opt_defined(&self, nm: &str) -> bool {
+        find_opt(&self.opts, Name::from_str(nm)).is_some()
+    }
 
     /// Returns true if an option was matched.
     pub fn opt_present(&self, nm: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,7 +748,7 @@ impl Matches {
     fn opt_vals(&self, nm: &str) -> Vec<Optval> {
         match find_opt(&self.opts, Name::from_str(nm)) {
             Some(id) => self.vals[id].clone(),
-            None => panic!("No option '{}' defined", nm)
+            None => vec![]
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,7 +748,7 @@ impl Matches {
     fn opt_vals(&self, nm: &str) -> Vec<Optval> {
         match find_opt(&self.opts, Name::from_str(nm)) {
             Some(id) => self.vals[id].clone(),
-            None => vec![]
+            None => Vec::new()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1816,7 +1816,15 @@ Options:
         debug!("generated: <<{}>>", generated_usage);
         assert_eq!(generated_usage, expected);
     }
-
+    #[test]
+    fn test_nonexistant_opt() {
+        let mut opts = Options::new();
+        opts.optflag("b", "bar", "Desc");
+        let args: Vec<String> = Vec::new();
+        let matches = opts.parse(&args).unwrap();
+        assert_eq!(matches.opt_defined("foo"), false);
+        assert_eq!(matches.opt_defined("bar"), true);
+    }
     #[test]
     fn test_args_with_equals() {
         let mut opts = Options::new();


### PR DESCRIPTION
Basically, this just returns an empty vector instead of panicking when an invalid option is passed