### PR TITLE
Parse using peekable iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ impl Options {
                            interpreted correctly
                         */
 
-                        let opt_id = match find_opt(&opts, opt.clone()) {
+                        let opt_id = match find_opt(&opts, &opt) {
                           Some(id) => id,
                           None => return Err(UnrecognizedOption(opt.to_string()))
                         };
@@ -382,7 +382,7 @@ impl Options {
                 let mut name_pos = 0;
                 for nm in names.iter() {
                     name_pos += 1;
-                    let optid = match find_opt(&opts, (*nm).clone()) {
+                    let optid = match find_opt(&opts, &nm) {
                       Some(id) => id,
                       None => return Err(UnrecognizedOption(nm.to_string()))
                     };
@@ -750,7 +750,7 @@ impl OptGroup {
 
 impl Matches {
     fn opt_vals(&self, nm: &str) -> Vec<Optval> {
-        match find_opt(&self.opts, Name::from_str(nm)) {
+        match find_opt(&self.opts, &Name::from_str(nm)) {
             Some(id) => self.vals[id].clone(),
             None => panic!("No option '{}' defined", nm)
         }
@@ -761,7 +761,7 @@ impl Matches {
     }
     /// Returns true if an option was defined
     pub fn opt_defined(&self, nm: &str) -> bool {
-        find_opt(&self.opts, Name::from_str(nm)).is_some()
+        find_opt(&self.opts, &Name::from_str(nm)).is_some()
     }
 
     /// Returns true if an option was matched.
@@ -777,7 +777,7 @@ impl Matches {
     /// Returns true if any of several options were matched.
     pub fn opts_present(&self, names: &[String]) -> bool {
         names.iter().any(|nm| {
-            match find_opt(&self.opts, Name::from_str(&nm)) {
+            match find_opt(&self.opts, &Name::from_str(&nm)) {
                 Some(id) if !self.vals[id].is_empty() => true,
                 _ => false,
             }
@@ -835,16 +835,16 @@ fn is_arg(arg: &str) -> bool {
     arg.as_bytes().get(0) == Some(&b'-') && arg.len() > 1
 }
 
-fn find_opt(opts: &[Opt], nm: Name) -> Option<usize> {
+fn find_opt(opts: &[Opt], nm: &Name) -> Option<usize> {
     // Search main options.
-    let pos = opts.iter().position(|opt| opt.name == nm);
+    let pos = opts.iter().position(|opt| &opt.name == nm);
     if pos.is_some() {
         return pos
     }
 
     // Search in aliases.
     for candidate in opts.iter() {
-        if candidate.aliases.iter().position(|opt| opt.name == nm).is_some() {
+        if candidate.aliases.iter().position(|opt| &opt.name == nm).is_some() {
             return opts.iter().position(|opt| opt.name == candidate.name);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,36 +307,27 @@ impl Options {
         where C::Item: AsRef<OsStr>
     {
         let opts: Vec<Opt> = self.grps.iter().map(|x| x.long_to_short()).collect();
-        let n_opts = opts.len();
 
-        fn f(_x: usize) -> Vec<Optval> { return Vec::new(); }
-
-        let mut vals = (0 .. n_opts).map(f).collect::<Vec<_>>();
+        let mut vals = (0 .. opts.len()).map(|_| Vec::new()).collect::<Vec<Vec<Optval>>>();
         let mut free: Vec<String> = Vec::new();
-        let args = try!(args.into_iter().map(|i| {
+        let args = args.into_iter().map(|i| {
             i.as_ref().to_str().ok_or_else(|| {
                 Fail::UnrecognizedOption(format!("{:?}", i.as_ref()))
             }).map(|s| s.to_owned())
-        }).collect::<::std::result::Result<Vec<_>, _>>());
-        let l = args.len();
-        let mut i = 0;
-        while i < l {
-            let cur = args[i].clone();
-            let curlen = cur.len();
+        }).collect::<::std::result::Result<Vec<_>,_>>()?;
+        let mut args = args.into_iter().peekable();
+        while let Some(cur) = args.next() {
             if !is_arg(&cur) {
                 match self.parsing_style {
                     ParsingStyle::FloatingFrees => free.push(cur),
                     ParsingStyle::StopAtFirstFree => {
-                        while i < l {
-                            free.push(args[i].clone());
-                            i += 1;
-                        }
+                        free.push(cur);
+                        free.extend(args);
                         break;
                     }
                 }
             } else if cur == "--" {
-                let mut j = i + 1;
-                while j < l { free.push(args[j].clone()); j += 1; }
+                free.extend(args);
                 break;
             } else {
                 let mut names;
@@ -344,10 +335,10 @@ impl Options {
                 let mut was_long = true;
                 if cur.as_bytes()[1] == b'-' || self.long_only {
                     let tail = if cur.as_bytes()[1] == b'-' {
-                        &cur[2..curlen]
+                        &cur[2..]
                     } else {
                         assert!(self.long_only);
-                        &cur[1..curlen]
+                        &cur[1..]
                     };
                     let tail_eq: Vec<&str> = tail.splitn(2, '=').collect();
                     if tail_eq.len() <= 1 {
@@ -384,8 +375,8 @@ impl Options {
 
                         if arg_follows {
                             let next = j + ch.len_utf8();
-                            if next < curlen {
-                                i_arg = Some(cur[next..curlen].to_string());
+                            if next < cur.len() {
+                                i_arg = Some(cur[next..].to_string());
                                 break;
                             }
                         }
@@ -412,41 +403,34 @@ impl Options {
                         // then users could only write a "Maybe" long
                         // option at the end of the arguments when
                         // FloatingFrees is in use.
-                        if !i_arg.is_none() {
-                            vals[optid]
-                                .push(Val((i_arg.clone())
-                                .unwrap()));
-                        } else if was_long || name_pos < names.len() || i + 1 == l ||
-                                is_arg(&args[i + 1]) {
+                        if let Some(i_arg) = i_arg.take() {
+                            vals[optid].push(Val(i_arg));
+                        } else if was_long || name_pos < names.len() || args.peek().map_or(true, |n| is_arg(&n)) {
                             vals[optid].push(Given);
                         } else {
-                            i += 1;
-                            vals[optid].push(Val(args[i].clone()));
+                            vals[optid].push(Val(args.next().unwrap()));
                         }
                       }
                       Yes => {
-                        if !i_arg.is_none() {
-                            vals[optid].push(Val(i_arg.clone().unwrap()));
-                        } else if i + 1 == l {
-                            return Err(ArgumentMissing(nm.to_string()));
+                        if let Some(i_arg) = i_arg.take() {
+                            vals[optid].push(Val(i_arg));
+                        } else if let Some(n) = args.next() {
+                            vals[optid].push(Val(n));
                         } else {
-                            i += 1;
-                            vals[optid].push(Val(args[i].clone()));
+                            return Err(ArgumentMissing(nm.to_string()));
                         }
                       }
                     }
                 }
             }
-            i += 1;
         }
-        for i in 0 .. n_opts {
-            let n = vals[i].len();
-            let occ = opts[i].occur;
-            if occ == Req && n == 0 {
-                return Err(OptionMissing(opts[i].name.to_string()));
+        debug_assert_eq!(vals.len(), opts.len());
+        for (vals, opt) in vals.iter().zip(opts.iter()) {
+            if opt.occur == Req && vals.is_empty() {
+                return Err(OptionMissing(opt.name.to_string()));
             }
-            if occ != Multi && n > 1 {
-                return Err(OptionDuplicated(opts[i].name.to_string()));
+            if opt.occur != Multi && vals.len() > 1 {
+                return Err(OptionDuplicated(opt.name.to_string()));
             }
         }
         Ok(Matches {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1232,6 +1232,37 @@ mod tests {
     }
 
     #[test]
+    fn test_opt_end() {
+        let args = vec!["--".to_owned(), "-t".to_owned()];
+        match Options::new()
+                      .optflag("t", "test", "testing")
+                      .parse(&args) {
+          Ok(ref m) => {
+            assert!(!m.opt_present("test"));
+            assert!(!m.opt_present("t"));
+            assert_eq!(m.free.len(), 1);
+            assert_eq!(m.free[0], "-t");
+          }
+          _ => panic!()
+        }
+    }
+
+    #[test]
+    fn test_opt_only_end() {
+        let args = vec!["--".to_owned()];
+        match Options::new()
+                      .optflag("t", "test", "testing")
+                      .parse(&args) {
+          Ok(ref m) => {
+            assert!(!m.opt_present("test"));
+            assert!(!m.opt_present("t"));
+            assert_eq!(m.free.len(), 0);
+          }
+          _ => panic!()
+        }
+    }
+
+    #[test]
     fn test_optflag_long_arg() {
         let args = vec!("--test=20".to_string());
         match Options::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,10 +318,10 @@ impl Options {
         let mut args = args.into_iter().peekable();
         while let Some(cur) = args.next() {
             if !is_arg(&cur) {
+                free.push(cur);
                 match self.parsing_style {
-                    ParsingStyle::FloatingFrees => free.push(cur),
+                    ParsingStyle::FloatingFrees => {},
                     ParsingStyle::StopAtFirstFree => {
-                        free.push(cur);
                         free.extend(args);
                         break;
                     }
@@ -340,13 +340,10 @@ impl Options {
                         assert!(self.long_only);
                         &cur[1..]
                     };
-                    let tail_eq: Vec<&str> = tail.splitn(2, '=').collect();
-                    if tail_eq.len() <= 1 {
-                        names = vec!(Name::from_str(tail));
-                    } else {
-                        names =
-                            vec!(Name::from_str(tail_eq[0]));
-                        i_arg = Some(tail_eq[1].to_string());
+                    let mut parts = tail.splitn(2, '=');
+                    names = vec![Name::from_str(parts.next().unwrap())];
+                    if let Some(rest) = parts.next() {
+                        i_arg = Some(rest.to_string());
                     }
                 } else {
                     was_long = false;


### PR DESCRIPTION
Juggling of offsets didn't seem Rusty. Parsing using an iterator allows consuming strings as they're parsed, so they don't need to be cloned.