### PR TITLE
doc: remove patch release semver from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-getopts = "0.2.4"
+getopts = "0.2"
 ```
 
 and this to your crate root:


### PR DESCRIPTION
Dont mention the patch release to keep the readme in-sync with the other
nursery docs. Right now the patch release is also outdated.