### PR TITLE
add: usage_with_format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@ impl Options {
 
     /// Derive a custom formatted message from a set of options. The formatted options provided to
     /// a closure as an iterator.
-    pub fn usage_with_format<'a, F: FnMut(&mut Iterator<Item=String>) -> String>(&'a self, mut formatter: F) -> String {
+    pub fn usage_with_format<F: FnMut(&mut Iterator<Item=String>) -> String>(&self, mut formatter: F) -> String {
         let mut items = self.usage_items();
         formatter(items.as_mut())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,8 +457,7 @@ impl Options {
     /// Derive a custom formatted message from a set of options. The formatted options provided to
     /// a closure as an iterator.
     pub fn usage_with_format<F: FnMut(&mut Iterator<Item=String>) -> String>(&self, mut formatter: F) -> String {
-        let mut items = self.usage_items();
-        formatter(items.as_mut())
+        formatter(&mut self.usage_items())
     }
 
     /// Derive usage items from a set of options.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,11 +447,17 @@ impl Options {
         line
     }
 
+
     /// Derive a formatted message from a set of options.
     pub fn usage(&self, brief: &str) -> String {
-        let rows = self.usage_items();
-        format!("{}\n\nOptions:\n{}\n", brief,
-                rows.collect::<Vec<String>>().join("\n"))
+        self.usage_with_format(|opts|
+            format!("{}\n\nOptions:\n{}\n", brief, opts.collect::<Vec<String>>().join("\n")))
+    }
+
+    /// Derive a custom formatted message from a set of options. The formatted options provided to
+    /// a closure as an iterator.
+    pub fn usage_with_format<'a, F: FnMut(Box<Iterator<Item=String> + 'a>) -> String>(&'a self, mut formatter: F) -> String {
+        formatter(self.usage_items())
     }
 
     /// Derive usage items from a set of options.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,8 +456,9 @@ impl Options {
 
     /// Derive a custom formatted message from a set of options. The formatted options provided to
     /// a closure as an iterator.
-    pub fn usage_with_format<'a, F: FnMut(Box<Iterator<Item=String> + 'a>) -> String>(&'a self, mut formatter: F) -> String {
-        formatter(self.usage_items())
+    pub fn usage_with_format<'a, F: FnMut(&mut Iterator<Item=String>) -> String>(&'a self, mut formatter: F) -> String {
+        let mut items = self.usage_items();
+        formatter(items.as_mut())
     }
 
     /// Derive usage items from a set of options.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,15 +447,22 @@ impl Options {
         line
     }
 
-    /// Derive a usage message from a set of options.
+    /// Derive a formatted message from a set of options.
     pub fn usage(&self, brief: &str) -> String {
+        let rows = self.usage_items();
+        format!("{}\n\nOptions:\n{}\n", brief,
+                rows.collect::<Vec<String>>().join("\n"))
+    }
+
+    /// Derive usage items from a set of options.
+    pub fn usage_items<'a>(&'a self) -> Box<Iterator<Item=String> + 'a> {
         let desc_sep = format!("\n{}", repeat(" ").take(24).collect::<String>());
 
         let any_short = self.grps.iter().any(|optref| {
             optref.short_name.len() > 0
         });
 
-        let rows = self.grps.iter().map(|optref| {
+        let rows = self.grps.iter().map(move |optref| {
             let OptGroup{short_name,
                          long_name,
                          hint,
@@ -546,8 +553,7 @@ impl Options {
             row
         });
 
-        format!("{}\n\nOptions:\n{}\n", brief,
-                rows.collect::<Vec<String>>().join("\n"))
+       Box::new(rows)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ impl Options {
     }
 
     /// Derive usage items from a set of options.
-    pub fn usage_items<'a>(&'a self) -> Box<Iterator<Item=String> + 'a> {
+    fn usage_items<'a>(&'a self) -> Box<Iterator<Item=String> + 'a> {
         let desc_sep = format!("\n{}", repeat(" ").take(24).collect::<String>());
 
         let any_short = self.grps.iter().any(|optref| {


### PR DESCRIPTION
Currently the usage method does the formatting, and there's no way to change it. This add `usage_with_format` that takes a closure. 

private method `usage_items` returns the iterator of the options directly, `usage_with_format` sits on top it, and `usage` in turn sits on top of that.

```rust
/// Derive a formatted message from a set of options.
    pub fn usage(&self, brief: &str) -> String {
        self.usage_with_format(|opts|
            format!("{}\n\nOptions:\n{}\n", brief, opts.collect::<Vec<String>>().join("\n")))
    }

    /// Derive a custom formatted message from a set of options. The formatted options provided to
    /// a closure as an iterator.
    pub fn usage_with_format<'a, F: FnMut(Box<Iterator<Item=String> + 'a>) -> String>(&'a self, mut formatter: F) -> String {
        formatter(self.usage_items())
    }
```

Addresses https://github.com/rust-lang-nursery/getopts/issues/58