### PR TITLE
Please publish a new version on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "getopts"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
0.2.15 does not build with non-lexical lifetimes enabled: https://github.com/rust-lang/rust/issues/47707 but `master` does.