### PR TITLE
Added note about a minimum version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.18.0 # don't forget to update the readme too
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ and this to your crate root:
 ```rust
 extern crate getopts;
 ```
+
+## Rust Version Support
+
+The minimum supported Rust version is 1.18.


### PR DESCRIPTION
I've used [biflags](https://github.com/rust-lang-nursery/bitflags#rust-version-support) as example for a readme note.

Closes #62