### PR TITLE
Add methods to `Matches` to support getting the index of an argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,6 +864,19 @@ impl Matches {
             }).collect()
     }
 
+    /// Returns a vector of the arguments provided to all matches of the given
+    /// option, together with their positions.
+    ///
+    /// Used when an option accepts multiple values.
+    pub fn opt_strs_pos(&self, nm: &str) -> Vec<(usize, String)> {
+        self.opt_vals(nm)
+            .into_iter()
+            .filter_map(|(p, v)| match v {
+                Val(s) => Some((p, s)),
+                _ => None,
+            }).collect()
+    }
+
     /// Returns the string argument supplied to a matching option or `None`.
     pub fn opt_str(&self, nm: &str) -> Option<String> {
         match self.opt_val(nm) {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1193,6 +1193,7 @@ fn test_opt_get_default() {
 fn test_opt_positions() {
     let mut opts = Options::new();
     opts.optflagmulti("a", "act", "Description");
+    opts.optflagmulti("e", "enact", "Description");
     opts.optflagmulti("r", "react", "Description");
 
     let args: Vec<String> = ["-a", "-a", "-r", "-a", "-r", "-r"]
@@ -1207,6 +1208,8 @@ fn test_opt_positions() {
 
     let a_pos = matches.opt_positions("a");
     assert_eq!(a_pos, vec![0, 1, 3]);
-    let b_pos = matches.opt_positions("r");
-    assert_eq!(b_pos, vec![2, 4, 5]);
+    let e_pos = matches.opt_positions("e");
+    assert_eq!(e_pos, vec![]);
+    let r_pos = matches.opt_positions("r");
+    assert_eq!(r_pos, vec![2, 4, 5]);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -909,7 +909,7 @@ Options:
     -c, --brûlée        brûlée quite long description
     -k, --kiwi€         kiwi description
     -o, --orange‹       orange description
-    -r, --raspberry-but-making-this-option-way-too-long 
+    -r, --raspberry-but-making-this-option-way-too-long\u{0020}
                         raspberry description is also quite long indeed longer
                         than every other piece of text we might encounter here
                         and thus will be automatically broken up
@@ -1212,4 +1212,29 @@ fn test_opt_positions() {
     assert_eq!(e_pos, vec![]);
     let r_pos = matches.opt_positions("r");
     assert_eq!(r_pos, vec![2, 4, 5]);
+}
+
+#[test]
+fn test_opt_strs_pos() {
+    let mut opts = Options::new();
+    opts.optmulti("a", "act", "Description", "NUM");
+    opts.optmulti("e", "enact", "Description", "NUM");
+    opts.optmulti("r", "react", "Description", "NUM");
+
+    let args: Vec<String> = ["-a1", "-a2", "-r3", "-a4", "-r5", "-r6"]
+        .iter()
+        .map(|x| x.to_string())
+        .collect();
+
+    let matches = &match opts.parse(&args) {
+        Ok(m) => m,
+        Err(e) => panic!("{}", e),
+    };
+
+    let a_pos = matches.opt_strs_pos("a");
+    assert_eq!(a_pos, vec![(0, "1".to_string()), (1, "2".to_string()), (3, "4".to_string())]);
+    let e_pos = matches.opt_strs_pos("e");
+    assert_eq!(e_pos, vec![]);
+    let r_pos = matches.opt_strs_pos("r");
+    assert_eq!(r_pos, vec![(2, "3".to_string()), (4, "5".to_string()), (5, "6".to_string())]);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1188,3 +1188,25 @@ fn test_opt_get_default() {
     let p_arg = matches.opt_get_default("p", 10.2);
     assert_eq!(p_arg, Ok(1.1));
 }
+
+#[test]
+fn test_opt_positions() {
+    let mut opts = Options::new();
+    opts.optflagmulti("a", "act", "Description");
+    opts.optflagmulti("r", "react", "Description");
+
+    let args: Vec<String> = ["-a", "-a", "-r", "-a", "-r", "-r"]
+        .iter()
+        .map(|x| x.to_string())
+        .collect();
+
+    let matches = &match opts.parse(&args) {
+        Ok(m) => m,
+        Err(e) => panic!("{}", e),
+    };
+
+    let a_pos = matches.opt_positions("a");
+    assert_eq!(a_pos, vec![0, 1, 3]);
+    let b_pos = matches.opt_positions("r");
+    assert_eq!(b_pos, vec![2, 4, 5]);
+}


### PR DESCRIPTION
This adds two methods:
- `Matches::opt_positions`
- `Matches::opt_strs_pos`
which give a way to get all the positions in which an argument was specified. This is used to decide which argument should take precedence in a case like https://github.com/rust-lang/rust/issues/32352.