### PR TITLE
Prepare for 0.2.19 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "getopts"
-version = "0.2.18" # don't forget to update html_root_url
+version = "0.2.19" # don't forget to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getopts/0.2.18"
+    html_root_url = "https://docs.rs/getopts/0.2.19"
 )]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]


### PR DESCRIPTION
[Diff since the last release](https://github.com/rust-lang-nursery/getopts/compare/v0.2.18...master)

Includes:

- #76 
- #77 
- #79 