### PR TITLE
Parse optional short options like gnu getopt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,6 @@ impl Options {
             } else {
                 let mut names;
                 let mut i_arg = None;
-                let mut was_long = true;
                 if cur.as_bytes()[1] == b'-' || self.long_only {
                     let tail = if cur.as_bytes()[1] == b'-' {
                         &cur[2..]
@@ -396,7 +395,6 @@ impl Options {
                         i_arg = Some(rest.to_string());
                     }
                 } else {
-                    was_long = false;
                     names = Vec::new();
                     for (j, ch) in cur.char_indices().skip(1) {
                         let opt = Short(ch);
@@ -444,21 +442,16 @@ impl Options {
                             vals[optid].push((arg_pos, Given));
                         }
                         Maybe => {
-                            // Note that here we do not handle `--arg value`.
-                            // This matches GNU getopt behavior; but also
-                            // makes sense, because if this were accepted,
-                            // then users could only write a "Maybe" long
-                            // option at the end of the arguments when
-                            // FloatingFrees is in use.
+                            // Note that here we do not handle `--arg value` or
+                            // `-a value`. This matches GNU getopt behavior; but
+                            // also makes sense, because if this were accepted,
+                            // then users could only write a "Maybe" option at
+                            // the end of the arguments when FloatingFrees is in
+                            // use.
                             if let Some(i_arg) = i_arg.take() {
                                 vals[optid].push((arg_pos, Val(i_arg)));
-                            } else if was_long
-                                || name_pos < names.len()
-                                || args.peek().map_or(true, |n| is_arg(&n))
-                            {
-                                vals[optid].push((arg_pos, Given));
                             } else {
-                                vals[optid].push((arg_pos, Val(args.next().unwrap())));
+                                vals[optid].push((arg_pos, Given));
                             }
                         }
                         Yes => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ impl Options {
                     .ok_or_else(|| Fail::UnrecognizedOption(format!("{:?}", i.as_ref())))
                     .map(|s| s.to_owned())
             }).collect::<::std::result::Result<Vec<_>, _>>()?;
-        let mut args = args.into_iter().peekable();
+        let mut args = args.into_iter();
         let mut arg_pos = 0;
         while let Some(cur) = args.next() {
             if !is_arg(&cur) {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -379,8 +379,8 @@ fn test_optflagopt() {
     let short_args = vec!["-t".to_string(), "x".to_string()];
     match opts.parse(&short_args) {
         Ok(ref m) => {
-            assert_eq!(m.opt_str("t").unwrap(), "x");
-            assert_eq!(m.opt_str("test").unwrap(), "x");
+            assert_eq!(m.opt_str("t"), None);
+            assert_eq!(m.opt_str("test"), None);
         }
         _ => panic!(),
     }
@@ -1148,7 +1148,7 @@ fn test_opt_get() {
     opts.optflagopt("p", "percent", "Description", "0.0 .. 10.0");
     opts.long_only(false);
 
-    let args: Vec<String> = ["-i", "true", "-p", "1.1"]
+    let args: Vec<String> = ["--ignore=true", "-p1.1"]
         .iter()
         .map(|x| x.to_string())
         .collect();
@@ -1173,7 +1173,7 @@ fn test_opt_get_default() {
     opts.optflagopt("p", "percent", "Description", "0.0 .. 10.0");
     opts.long_only(false);
 
-    let args: Vec<String> = ["-i", "true", "-p", "1.1"]
+    let args: Vec<String> = ["--ignore=true", "-p1.1"]
         .iter()
         .map(|x| x.to_string())
         .collect();


### PR DESCRIPTION
Similar to https://github.com/rust-lang-nursery/getopts/issues/49, this changes the parsing of optional short options to require no space between the option and argument. Now, `-aSomething` parse as an option with argument, and `-a Something` will parse as a present flag with a free non-option.

Note that this only changes _optional_ option arguments (when `hasarg = Maybe`, as in `optflagopt`). Required option arguments (when `hasarg = Yes`, as in `optopt`) still allow a space between the short option and its argument.

This is a breaking change.
