### PR TITLE
Update support for being built in rust-lang/rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ categories = ["command-line-interface"]
 
 [dependencies]
 unicode-width = "0.1.5"
+std = { version = "1.0", package = "rustc-std-workspace-std", optional = true }
 
 [dev-dependencies]
 log = "0.4"
+
+[features]
+rustc-dep-of-std = ['unicode-width/rustc-dep-of-std', 'std']


### PR DESCRIPTION
This commit updates the support necessary for this crate to be built as
a dependency of `getopts` which is a dependency of the `test` crate
which is built in rust-lang/rust. This change will be required to land
rust-lang/rust#63637 where Rust's build system is being tweaked
slightly. This is intended to not have any impact on other users of this
crate and the `Cargo.toml` features here should only be used by Rust's
own build system.